### PR TITLE
Management command for translations publication after deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ if typing.TYPE_CHECKING:
     
 COEX_TRANSLATOR: "CoexTranslatorSettings" = {
     "API_BASE_URL": config('COEX_TRANSLATOR_API_BASE_URL', default=''),
+    "API_TOKEN": config('COEX_TRANSLATOR_API_TOKEN', default=''),
     "UVICORN_RELOAD_FILE_PATH": config('COEX_TRANSLATOR_UVICORN_RELOAD_FILE_PATH', default=''),
     "STARTUP_REFRESH_ENABLED": config('COEX_TRANSLATOR_STARTUP_REFRESH_ENABLED', default=False, cast=bool),
     "AMQP": {

--- a/coex_translator/app_settings.py
+++ b/coex_translator/app_settings.py
@@ -7,6 +7,7 @@ SETTINGS_NAME: str = "COEX_TRANSLATOR"
 class CoexTranslatorSettings(typing.TypedDict):
     """Settings of the CoexTranslator app."""
     API_BASE_URL: str  # URL to the Translator service API
+    API_TOKEN: str
     UVICORN_RELOAD_FILE_PATH: typing.NotRequired[str]
     STARTUP_REFRESH_ENABLED: bool  # If True -> when app is reloaded, refresh translations
     FETCH_WITH_FE: bool

--- a/coex_translator/internal/clients/translator/client.py
+++ b/coex_translator/internal/clients/translator/client.py
@@ -10,6 +10,7 @@ from coex_translator.internal.clients.translator import schemas
 
 class TranslatorClient(base.BaseAuthHttpClient):  # TODO set up auth token?
     base_url: typing.ClassVar[str] = app_settings["API_BASE_URL"]
+    token: typing.ClassVar[str] = app_settings['API_TOKEN']
 
     def fetch_translations(
             self,
@@ -54,3 +55,19 @@ class TranslatorClient(base.BaseAuthHttpClient):  # TODO set up auth token?
                 ),
             ).dict(),
         )
+
+    def publish_translations(self, environment: str) -> schemas.PublishTranslationsResponseSchema:
+        """
+        Publish translations for given environment.
+
+        :param environment: Name of the environment.
+        """
+        resp: requests.Response = self._send_post_request(
+            url=f"{self.base_url}/translation/publish",
+            data=schemas.PublishTranslationsRequestSchema(
+                environments=[environment],
+                app_name=constants.BE_APP_NAME,
+            ).dict(),
+        )
+
+        return schemas.PublishTranslationsResponseSchema.build(resp.json())

--- a/coex_translator/internal/clients/translator/schemas.py
+++ b/coex_translator/internal/clients/translator/schemas.py
@@ -63,3 +63,35 @@ class ExportMessagesRequestSchema(base.ClientRequestDataSchema):
     language: str = settings.LANGUAGE_CODE
     environment: str = settings.ENVIRONMENT
     app_name: str = settings.PROJECT_NAME
+
+
+@dataclasses.dataclass(kw_only=True)
+class PublishTranslationsRequestSchema(base.ClientRequestDataSchema):
+    environments: list[str] = lambda: [settings.ENVIRONMENT]
+    app_name: str
+
+
+@dataclasses.dataclass(kw_only=True)
+class PublishTranslationsItemResponseSchema(base.ClientResponseDataSchema):
+    total: int
+    new: int
+    language: str
+
+    @classmethod
+    def build(cls, data: dict[str, typing.Any]) -> typing.Self:
+        return cls(
+            total=data['total'],
+            new=data['new'],
+            language=data['language'],
+        )
+
+
+@dataclasses.dataclass(kw_only=True)
+class PublishTranslationsResponseSchema(base.ClientResponseDataSchema):
+    items: list[PublishTranslationsItemResponseSchema]
+
+    @classmethod
+    def build(cls, data: dict) -> typing.Self:
+        return cls(
+            items=[PublishTranslationsItemResponseSchema.build(item) for item in data['items']],
+        )

--- a/coex_translator/management/commands/publish_translations.py
+++ b/coex_translator/management/commands/publish_translations.py
@@ -1,0 +1,28 @@
+from django.core.management import BaseCommand, CommandError
+
+from coex_translator.internal import clients
+
+
+class Command(BaseCommand):
+    help = ('Publish translations in COex Translator to the storage and notify the containers to refresh them.'
+            ' Usable after deploy')
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'environment',
+            help="Environment to publish translations to. Currently must be one of: 'testing', 'production",
+        )
+        return parser
+
+    def handle(self, *args, **options):
+
+        environment = args[0]
+
+        if environment not in ['testing', 'production']:  # Hardcoded, modify with COex translator
+            raise CommandError('Environment must be one of: "testing", "production"')
+
+        self.stdout.write(f"Calling COex Translator API to publish translations for environment {environment}.")
+
+        publish_results = clients.TranslatorClient().publish_translations(environment)
+
+        self.stdout.write(f"Done. Publish results are: {publish_results.items}.")

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -151,6 +151,7 @@ CACHES = {
 
 COEX_TRANSLATOR: "CoexTranslatorSettings" = {
     "API_BASE_URL": config('COEX_TRANSLATOR_API_BASE_URL', default=''),
+    "API_TOKEN": config('COEX_TRANSLATOR_API_TOKEN', default=''),
     "UVICORN_RELOAD_FILE_PATH": config('COEX_TRANSLATOR_UVICORN_RELOAD_FILE_PATH', default=''),
     "STARTUP_REFRESH_ENABLED": config('COEX_TRANSLATOR_STARTUP_REFRESH_ENABLED', default=False, cast=bool),
     'FETCH_WITH_FE': False,

--- a/test_project/tests/fixtures/translator_service/publish_translations_response.json
+++ b/test_project/tests/fixtures/translator_service/publish_translations_response.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "total": 10,
+      "new": 2,
+      "language": "en"
+    },
+    {
+      "total": 10,
+      "new": 10,
+      "language": "cs"
+    }
+  ]
+}

--- a/test_project/tests/test_translator_client.py
+++ b/test_project/tests/test_translator_client.py
@@ -60,5 +60,22 @@ class TranslatorClientTestCase(TestCase):
             with self.assertRaises(self.trans_client.exception_cls):
                 self.trans_client.fetch_translations()
 
-    # TODO test invalid format of the response
+    def test_publish_translations(self):
+        fixture_data: list[dict] = load_fixture('translator_service/publish_translations_response.json')
+        mock_resp = MockResponse(data=fixture_data)
+        with mock.patch('requests.request', return_value=mock_resp) as request_mock:
+            publish_results = self.trans_client.publish_translations('testing')
+            request_mock.assert_called_once_with(
+                'post',
+                url=f"{app_settings['API_BASE_URL']}/translation/publish",
+                json={
+                    'environments': ['testing'],
+                    'app_name': constants.BE_APP_NAME
+                },
+                headers={
+                    'X-Authorization': f'Bearer {self.trans_client.token}',
+                },
+                params={}
+            )
 
+            self.assertEqual(len(publish_results.items), len(fixture_data['items']))


### PR DESCRIPTION
Management command, který se přidá do `web_once` kontejneru pro swarm, případně sidecar v k8s pro automatickou publikaci překladů po nasazení. 